### PR TITLE
Fix bug with IMAGE_INSTALL can not be append

### DIFF
--- a/recipes-images/images/console-hostmobility-image.bb
+++ b/recipes-images/images/console-hostmobility-image.bb
@@ -31,14 +31,14 @@ IMAGE_INSTALL += " \
     uart-test \
 "
 
-IMAGE_INSTALL_append_tegra3mainline += " \
+IMAGE_INSTALL_tegra3mainline += " \
     libgpiod \
     ntpdate \
     lrzsz \
     lmsensors-sensors \
 "
 
-IMAGE_INSTALL_append_mx6 += " \
+IMAGE_INSTALL_mx6 += " \
     packagegroup-core-full-cmdline-utils \
     packagegroup-base \
     packagegroup-imx-tools-audio \

--- a/recipes-images/images/mobility-image-development.bb
+++ b/recipes-images/images/mobility-image-development.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "A console-only image that includes gstreamer packages, \
 Freescale's multimedia packages (VPU and GPU) when available, and \
 test and benchmark applications."
 
-IMAGE_FEATURES += " \
+IMAGE_FEATURES_append += " \
     tools-debug \
     tools-profile \
     splash \

--- a/recipes-images/images/mobility-image-xfce.bb
+++ b/recipes-images/images/mobility-image-xfce.bb
@@ -7,7 +7,7 @@ LICENSE = "MIT"
 
 require mobility-image.bb
 
-IMAGE_INSTALL_append += " \
+IMAGE_INSTALL += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-xfce-base', '', d)} \
 "
 

--- a/recipes-images/images/mobility-image.bb
+++ b/recipes-images/images/mobility-image.bb
@@ -7,7 +7,7 @@ LICENSE = "MIT"
 
 require console-hostmobility-image.bb
 
-IMAGE_FEATURES += " \
+IMAGE_FEATURES_append += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '', \
        bb.utils.contains('DISTRO_FEATURES',     'x11', 'x11-base', \
                                                        '', d), d)} \
@@ -20,7 +20,7 @@ X11TOOLS = "\
     xprop \
 "
 
-IMAGE_INSTALL_append += " \
+IMAGE_INSTALL += " \
     packagegroup-hostmobility-net-extended \
     packagegroup-fsl-gstreamer1.0 \
     packagegroup-fsl-tools-gpu \


### PR DESCRIPTION
If we use require a recipe (image.bb) then this bug happens. it could not get
all grapics support in manifest like xauth. On poky it seems to work.

IMAGE_FEATURES need IMAGE_FEATURES_append if we add on. but this is what not works on IMAGE_INSTALL on Angstrom.