### PR TITLE
Change out sshdropbear on mx4 default

### DIFF
--- a/recipes-images/images/console-hostmobility-image.bb
+++ b/recipes-images/images/console-hostmobility-image.bb
@@ -16,6 +16,9 @@ IMAGE_FEATURES_mx6 += " \
     ssh-server-openssh \
 "
 
+#For packagegroup-basic use this instead of sshdropbear
+TASK_BASIC_SSHDAEMON = "openssh-sshd openssh-sftp openssh-sftp-server"
+
 IMAGE_INSTALL += " \
     packagegroup-basic \
     packagegroup-base-extended \


### PR DESCRIPTION
sshdropbear takes to long to establish a connection and it was slower in perfomance when tested it on mx5.